### PR TITLE
feat: Add resume link to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,7 @@
       <nav>
         <ul>
           <li class="nav-item"><a href="/work.html" aria-labelledby="work" data-view-transition>work</a></li>
+          <li class="nav-item"><a href="resume.html">resume</a></li>
         </ul>
       </nav>
     </header>

--- a/lab.html
+++ b/lab.html
@@ -68,6 +68,7 @@
       <nav>
         <ul>
           <li><a href="work.html">work</a></li>
+          <li class="nav-item"><a href="resume.html">resume</a></li>
         </ul>
       </nav>
     </header>

--- a/work.html
+++ b/work.html
@@ -68,6 +68,7 @@
       <nav>
         <ul>
           <li class='nav-item'><a href="/work.html">work</a></li>
+          <li class="nav-item"><a href="resume.html">resume</a></li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
I've added a 'resume' link to the main navigation header in the following files:
- index.html
- lab.html
- work.html

The link points to resume.html. The file pattern-library.html was not modified as it has a different header structure without a navigation list.