### PR TITLE
I've added border animations to your header navigation links.

### DIFF
--- a/scripts/nav-transitions.js
+++ b/scripts/nav-transitions.js
@@ -1,41 +1,112 @@
 // scripts/nav-transitions.js
 document.addEventListener('DOMContentLoaded', () => {
   const navLinks = document.querySelectorAll('header nav ul li a');
-  const currentPath = window.location.pathname;
+  const currentPath = window.location.pathname.endsWith('/') && window.location.pathname.length > 1 ? window.location.pathname.slice(0, -1) : window.location.pathname;
+
+  const pagePaths = {
+    home: ['', '/', '/index.html'], // Added '' for root path
+    work: ['/work.html'],
+    resume: ['/resume.html']
+  };
+
+  function getPageKey(path) {
+    for (const key in pagePaths) {
+      if (pagePaths[key].includes(path)) {
+        return key;
+      }
+    }
+    return null;
+  }
+
+  const currentPageKey = getPageKey(currentPath);
 
   navLinks.forEach(link => {
-    if (link.getAttribute('href') === currentPath) {
+    const linkHref = link.getAttribute('href');
+    const linkPageKey = getPageKey(linkHref);
+
+    // Set initial active state
+    if (linkPageKey === currentPageKey) {
       link.classList.add('active');
       link.style.viewTransitionName = 'active-nav-link';
+      // Set initial border for work/resume pages (visible without animation on load)
+      if (currentPageKey === 'work' || currentPageKey === 'resume') {
+        link.classList.add('force-border-full'); // Show border, no animation
+      }
     } else {
       link.classList.remove('active');
-      link.style.viewTransitionName = ''; // Remove for non-active links
+      link.style.viewTransitionName = '';
     }
 
     link.addEventListener('click', (event) => {
-      if (link.getAttribute('href') === currentPath) {
-        event.preventDefault(); // Don't navigate if already on the page
+      const targetHref = link.getAttribute('href');
+      const targetPageKey = getPageKey(targetHref);
+
+      if (targetPageKey === currentPageKey) {
+        event.preventDefault();
         return;
       }
 
       if (!document.startViewTransition) {
-        return; // Browser doesn't support View Transitions
+        window.location.href = targetHref; // Fallback
+        return;
       }
 
-      // Set view-transition-name on the clicked link before transition
-      navLinks.forEach(l => l.style.viewTransitionName = ''); // Clear old names
-      link.style.viewTransitionName = 'active-nav-link';
+      event.preventDefault();
+
+      // Clear previous animation classes and view transition names from all links
+      navLinks.forEach(l => {
+        l.classList.remove('animate-border-in', 'animate-border-out', 'force-border-full', 'active');
+        l.style.viewTransitionName = '';
+      });
+
+      // Logic for border animation on the CLICKED link
+      let animateOut = false;
+
+      // From Home to Work or Resume
+      if (currentPageKey === 'home' && (targetPageKey === 'work' || targetPageKey === 'resume')) {
+        link.classList.add('animate-border-in');
+      }
+      // From Work to Resume
+      else if (currentPageKey === 'work' && targetPageKey === 'resume') {
+        link.classList.add('animate-border-in');
+      }
+      // From Resume to Work or Home
+      else if (currentPageKey === 'resume' && (targetPageKey === 'work' || targetPageKey === 'home')) {
+        animateOut = true;
+      }
+      // From Work to Home
+      else if (currentPageKey === 'work' && targetPageKey === 'home') {
+        animateOut = true;
+      }
+
+      if (animateOut) {
+        link.classList.add('force-border-full'); // Set to 100% width, no transition
+        requestAnimationFrame(() => {
+          // Ensure force-border-full is applied and rendered
+          requestAnimationFrame(() => {
+            link.classList.remove('force-border-full'); // Remove it so transition can take effect
+            link.classList.add('animate-border-out'); // Animate 100% to 0%
+          });
+        });
+      }
+
+      link.style.viewTransitionName = 'active-nav-link'; // For the page transition itself
 
       const transition = document.startViewTransition(() => {
-        // This promise resolves when the new page's content is ready to be displayed
-        // but before it's actually rendered.
-        // We don't need to do anything specific here for the border,
-        // as the CSS and the 'active' class will handle the styling on the new page.
+        // The actual navigation will be handled by the browser resolving the href
+        // For SPA-like behavior or more control, you'd update content here.
+        // For MPA, we let the click proceed after setting up styles.
+        // Since we called preventDefault, we need to navigate manually.
+        window.location.href = targetHref;
       });
 
       transition.finished.then(() => {
-        // Clean up after transition if needed, though usually not necessary for this case
-        // The new page will set its own active link and view-transition-name
+        // Clean up on the link that was clicked.
+        // Note: When the new page loads, its own JS will run and set initial states.
+        // So, this cleanup might be redundant if full page reloads occur.
+        // However, it's good practice for View Transitions which can be very fast.
+        link.classList.remove('animate-border-in', 'animate-border-out', 'force-border-full');
+        // The 'active' class and 'active-nav-link' view transition name will be set by the script on the new page.
       });
     });
   });

--- a/styles/main.css
+++ b/styles/main.css
@@ -244,8 +244,35 @@ h1 {
   margin-block-end: 0.3rem;
 }
 
-nav li > a {
+header nav li a { /* Changed selector */
   filter: drop-shadow(.5px .5px 1px var(--text-shadow));
+  position: relative; /* For border positioning */
+  padding-bottom: 5px; /* Space for the border */
+}
+
+header nav li a::after { /* Changed selector */
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 2px; /* Border thickness */
+  background-color: var(--orange-3); /* Changed to --orange-3 */
+  width: 0; /* Initial width */
+  transition: width 0.5s ease-in-out; /* Animation */
+}
+
+header nav li a.animate-border-in::after { /* Changed selector */
+  width: 100%;
+}
+
+header nav li a.animate-border-out::after { /* Changed selector */
+  width: 0%;
+}
+
+/* Helper class to instantaneously set border to full width */
+header nav li a.force-border-full::after { /* Changed selector */
+  width: 100%;
+  transition: none; /* No transition when applying this class */
 }
 
 main { margin: auto; }


### PR DESCRIPTION
I implemented CSS and JavaScript to animate the bottom border of header navigation links during page transitions. The border color is now `var(--orange-3)`.

Here's how the animations work:
- Home -> Work/Resume: Border animates 0% to 100%.
- Work -> Resume: Border animates 0% to 100%.
- Resume -> Work/Home: Border animates 100% to 0%.
- Work -> Home: Border animates 100% to 0%.

I used the View Transitions API and careful class management. CSS selectors are scoped to `header nav`. I also included a helper CSS class `force-border-full` and used `requestAnimationFrame` for 'animate out' scenarios.