### PR TITLE
Migrate from Universal Analytics to Google Analytics 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="Description"
         content="Robert James - A UX Engineer who designs and builds digital experiences and products" />
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' https://assets.codepen.io data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
+        content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' https://assets.codepen.io data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <title>Robert James</title>
     <meta property="og:title" content="Robert James" />

--- a/lab.html
+++ b/lab.html
@@ -12,7 +12,7 @@
   <meta name="Description"
     content="Robert James - A UX Engineer who designs and builds digital experiences and products" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' https://assets.codepen.io data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
+    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:; img-src 'self' https://assets.codepen.io data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Lab | Portfolio</title>
   <meta property="og:title" content="Robert James" />

--- a/resume.html
+++ b/resume.html
@@ -12,7 +12,7 @@
   <meta name="Description"
     content="Robert James - A UX Engineer who designs and builds digital experiences and products" />
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' https://assets.codepen.io data:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
+    content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' https://assets.codepen.io data:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self'; upgrade-insecure-requests;" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <title>Resume | Portfolio</title>
   <meta property="og:title" content="Robert James" />

--- a/scripts/analytics-loader.js
+++ b/scripts/analytics-loader.js
@@ -25,7 +25,7 @@
     // Production: Load the real Google Analytics script
     const script = document.createElement('script');
     script.async = true;
-    script.src = 'https://www.googletagmanager.com/gtag/js?id=UA-51900523-1';
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=G-B51Q6R96Y5';
     document.head.appendChild(script);
 
     function gtag() {
@@ -33,6 +33,6 @@
     }
     window.gtag = gtag;
     gtag('js', new Date());
-    gtag('config', 'UA-51900523-1');
+    gtag('config', 'G-B51Q6R96Y5');
   }
 })();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const cacheName = 'v10'; // Bumped to v10 to inline fonts.css and fix cache cleanup
+const cacheName = 'v11'; // Bumped to v11 to support GA4 migration and CSP updates
 const OFFLINE = 'offline.html';
 
 const assetsToCache = [


### PR DESCRIPTION
This change migrates the analytics tracking from the deprecated Universal Analytics (UA) to Google Analytics 4 (GA4). It updates the loader script with the new Measurement ID, adjusts the Content Security Policy to permit GA4 network requests, and increments the Service Worker cache version to propagate these changes to returning visitors.

---
*PR created automatically by Jules for task [4216092953534486926](https://jules.google.com/task/4216092953534486926) started by @rmjames*