### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS risk and harden CSP in Media Player Selector

### DIFF
--- a/lab/media-player-selector.html
+++ b/lab/media-player-selector.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com 'unsafe-inline'; style-src 'self' 'unsafe-inline' data:; img-src 'self' https://assets.codepen.io data:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self';" />
+        content="default-src 'self'; script-src 'self' https://www.googletagmanager.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' data:; img-src 'self' https://assets.codepen.io data:; font-src 'self'; connect-src 'self' https://www.google-analytics.com https://cloudflareinsights.com https://static.cloudflareinsights.com; object-src 'none'; frame-src 'self'; base-uri 'self';" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -176,45 +176,7 @@
         </div>
     </nav>
 
-    <script>
-        const players = [
-            { title: "Main Media Player", url: "media-player.html" },
-            { title: "Inline Widget", url: "media-player-inline.html" },
-            { title: "Lock Screen Player", url: "media-player-lock-screen.html" },
-            { title: "Media Player Widget", url: "media-player-widget.html" }
-        ];
-
-        const carousel = document.getElementById('carousel');
-        const pagination = document.getElementById('pagination');
-
-
-        players.forEach((player, index) => {
-            const card = document.createElement('div');
-            card.className = 'player-card';
-            card.style.viewTimelineName = `--card-${index}`;
-            card.innerHTML = `
-                <div class="card-header"> 
-                    <h2>${player.title}</h2>
-                </div>
-                <iframe class="player-frame" src="${player.url}" loading="lazy"></iframe>
-            `;
-            carousel.appendChild(card);
-
-            const dot = document.createElement('div');
-            dot.className = 'dot';
-            dot.style.animationTimeline = `--card-${index}`;
-
-            dot.addEventListener('click', () => {
-                card.scrollIntoView({ behavior: 'smooth', inline: 'center' });
-            });
-            pagination.appendChild(dot);
-        });
-
-        window.addEventListener('keydown', (e) => {
-            if (e.key === 'ArrowLeft') carousel.scrollBy({ left: -window.innerWidth * 0.8, behavior: 'smooth' });
-            if (e.key === 'ArrowRight') carousel.scrollBy({ left: window.innerWidth * 0.8, behavior: 'smooth' });
-        });
-    </script>
+    <script type="module" src="../scripts/media/MediaPlayerSelector.js"></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "music-metadata": "^11.10.3",
     "playwright": "^1.57.0",
     "postcss-import": "^16.1.1",
+    "vite": "^7.3.1",
     "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       postcss-import:
         specifier: ^16.1.1
         version: 16.1.1(postcss@8.5.6)
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.0.9)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.0.9)(jsdom@27.4.0)(yaml@2.8.2)

--- a/scripts/media/MediaPlayerSelector.js
+++ b/scripts/media/MediaPlayerSelector.js
@@ -1,0 +1,49 @@
+const players = [
+    { title: "Main Media Player", url: "media-player.html" },
+    { title: "Inline Widget", url: "media-player-inline.html" },
+    { title: "Lock Screen Player", url: "media-player-lock-screen.html" },
+    { title: "Media Player Widget", url: "media-player-widget.html" }
+];
+
+const carousel = document.getElementById('carousel');
+const pagination = document.getElementById('pagination');
+
+if (carousel && pagination) {
+    players.forEach((player, index) => {
+        const card = document.createElement('div');
+        card.className = 'player-card';
+        card.style.viewTimelineName = `--card-${index}`;
+
+        // Create Header
+        const header = document.createElement('div');
+        header.className = 'card-header';
+        const h2 = document.createElement('h2');
+        h2.textContent = player.title;
+        header.appendChild(h2);
+        card.appendChild(header);
+
+        // Create Iframe
+        const iframe = document.createElement('iframe');
+        iframe.className = 'player-frame';
+        iframe.src = player.url;
+        iframe.loading = 'lazy';
+        card.appendChild(iframe);
+
+        carousel.appendChild(card);
+
+        // Create Dot
+        const dot = document.createElement('div');
+        dot.className = 'dot';
+        dot.style.animationTimeline = `--card-${index}`;
+
+        dot.addEventListener('click', () => {
+            card.scrollIntoView({ behavior: 'smooth', inline: 'center' });
+        });
+        pagination.appendChild(dot);
+    });
+
+    window.addEventListener('keydown', (e) => {
+        if (e.key === 'ArrowLeft') carousel.scrollBy({ left: -window.innerWidth * 0.8, behavior: 'smooth' });
+        if (e.key === 'ArrowRight') carousel.scrollBy({ left: window.innerWidth * 0.8, behavior: 'smooth' });
+    });
+}

--- a/tests-e2e/security.spec.js
+++ b/tests-e2e/security.spec.js
@@ -95,4 +95,14 @@ test.describe('Security Headers', () => {
       expect(content, `${file} referrer policy`).toBe('strict-origin-when-cross-origin');
     }
   });
+
+  test('lab/media-player-selector.html has strict CSP (no unsafe-inline in script-src)', async ({ page }) => {
+    await page.goto('/lab/media-player-selector.html');
+    const csp = await page.$('meta[http-equiv="Content-Security-Policy"]');
+    expect(csp).not.toBeNull();
+    const cspContent = await csp.getAttribute('content');
+    expect(cspContent).toContain("script-src 'self'");
+    const scriptSrc = cspContent.match(/script-src [^;]+/)[0];
+    expect(scriptSrc).not.toContain("'unsafe-inline'");
+  });
 });


### PR DESCRIPTION
Extracted inline script from `lab/media-player-selector.html` to `scripts/media/MediaPlayerSelector.js`, refactored to use `document.createElement` instead of `innerHTML`, and hardened the Content Security Policy by removing `'unsafe-inline'` from `script-src`. Also added `vite` to `devDependencies` to fix the local development environment.

---
*PR created automatically by Jules for task [7325592052993057136](https://jules.google.com/task/7325592052993057136) started by @rmjames*