### PR TITLE
🎨 Palette: Improve resume print experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "music-metadata": "^11.10.3",
     "playwright": "^1.57.0",
     "postcss-import": "^16.1.1",
+    "vite": "^7.3.1",
     "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       postcss-import:
         specifier: ^16.1.1
         version: 16.1.1(postcss@8.5.6)
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.0.9)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@25.0.9)(jsdom@27.4.0)(yaml@2.8.2)

--- a/resume.html
+++ b/resume.html
@@ -300,6 +300,7 @@
   <script src="scripts/copyright.js" defer></script>
   <script src="scripts/register-sw.js" defer></script>
   <script src="scripts/analytics.js" type="module" defer></script>
+  <script src="scripts/resume-print.js" type="module"></script>
 </body>
 
 </html>

--- a/scripts/resume-print.js
+++ b/scripts/resume-print.js
@@ -1,0 +1,28 @@
+const initResumePrint = () => {
+  // Select all job details that participate in the accordion
+  const details = document.querySelectorAll('details[name="job"]');
+
+  if (details.length === 0) return;
+
+  const handleBeforePrint = () => {
+    details.forEach((el) => {
+      // Save the current open state so we could theoretically restore it,
+      // but primarily we just need to re-add the name attribute.
+      // Removing 'name' breaks the exclusive accordion behavior, allowing all to be open.
+      el.removeAttribute('name');
+      el.open = true;
+    });
+  };
+
+  const handleAfterPrint = () => {
+    details.forEach((el) => {
+      // Restore the exclusive accordion behavior
+      el.setAttribute('name', 'job');
+    });
+  };
+
+  window.addEventListener('beforeprint', handleBeforePrint);
+  window.addEventListener('afterprint', handleAfterPrint);
+};
+
+initResumePrint();

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const cacheName = 'v11'; // Bumped to v11 to support GA4 migration and CSP updates
+const cacheName = 'v12'; // Bumped to v12 to include resume print script
 const OFFLINE = 'offline.html';
 
 const assetsToCache = [
@@ -26,7 +26,8 @@ const assetsToCache = [
   '/favicon_512.png',
   '/manifest.json',
   '/resume_icon.svg',
-  '/lab_icon.svg'
+  '/lab_icon.svg',
+  '/scripts/resume-print.js'
 ];
 
 self.addEventListener('install', event => {

--- a/tests-e2e/resume-print.spec.js
+++ b/tests-e2e/resume-print.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test('Resume expands details on print', async ({ page }) => {
+  await page.goto('/resume.html');
+  await page.waitForLoadState('networkidle');
+
+  // Verify initial state: at least one detail is open, but they have name="job"
+  const details = page.locator('details.job');
+  const count = await details.count();
+  expect(count).toBeGreaterThan(0);
+
+  // Check initial state: all should have name="job"
+  for (let i = 0; i < count; ++i) {
+    await expect(details.nth(i)).toHaveAttribute('name', 'job');
+  }
+
+  // Emulate beforeprint
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('beforeprint'));
+  });
+
+  // Verify they are all open and name is removed
+  for (let i = 0; i < count; ++i) {
+    await expect(details.nth(i)).toHaveAttribute('open', '');
+    await expect(details.nth(i)).not.toHaveAttribute('name');
+  }
+
+  // Emulate afterprint
+  await page.evaluate(() => {
+    window.dispatchEvent(new Event('afterprint'));
+  });
+
+  // Verify name is restored
+  for (let i = 0; i < count; ++i) {
+    await expect(details.nth(i)).toHaveAttribute('name', 'job');
+  }
+});


### PR DESCRIPTION
🎨 Palette: Improved the resume printing experience.

💡 **What:** Added logic to automatically expand all "Job Experience" accordions when the user prints the resume page.
🎯 **Why:** Previously, the exclusive accordion behavior (`name="job"`) meant users could only print one job detail at a time, hiding the rest of the resume content.
♿ **Accessibility:** This ensures the printed version of the resume is complete and readable, which is a critical alternative format for accessibility.
📸 **Verification:** Confirmed via E2E tests and manual print emulation that all sections expand correctly.

Note: Added `vite` to `devDependencies` as it was missing but required for running E2E tests.

---
*PR created automatically by Jules for task [8763307334243968389](https://jules.google.com/task/8763307334243968389) started by @rmjames*