### PR TITLE
Fix aspect ratio for lab page iframes and headphone animation durations

### DIFF
--- a/lab/headphones.html
+++ b/lab/headphones.html
@@ -174,8 +174,8 @@
     <script type="module">
         import { audioLibrary } from '../scripts/AudioLibrary.js';
 
-        const PREVIEW_DURATION_SEC = 44;
-        const FADE_DURATION_SEC = 8;
+        const PREVIEW_DURATION_SEC = 90;
+        const FADE_DURATION_SEC = 12;
 
         const btn = document.querySelector('.toggle-btn');
         const iconPath = btn.querySelector('path');

--- a/styles/components/lab.css
+++ b/styles/components/lab.css
@@ -75,7 +75,7 @@
     }
 
     & article>iframe {
-        aspect-ratio: 6/9;
+        aspect-ratio: 1;
         width: 100%;
         border: 0;
         border-radius: 1.5rem;


### PR DESCRIPTION
This submission implements changes to the lab examples:
1. It updates the aspect ratio of the iframes on the labs page from `6/9` to `1`, making them perfectly square.
2. It increases the duration variables for the headphones animation: `PREVIEW_DURATION_SEC` is changed to `90` (previously 44) and `FADE_DURATION_SEC` is changed to `12` (previously 8).

Frontend visual verification and unit tests were successfully executed to ensure correct functionality and layout changes.

---
*PR created automatically by Jules for task [8108887270100191431](https://jules.google.com/task/8108887270100191431) started by @rmjames*