### PR TITLE
Add External Links and Speculation Rules to Lab Page

### DIFF
--- a/lab.html
+++ b/lab.html
@@ -34,22 +34,15 @@
   <script src="scripts/favicon-animator.js" async></script>
   <script type="speculationrules">
     {
-      "prefetch": [{
-        "urls": [
-          "/lab/microsoft-logo.html",
-          "/lab/headphones.html",
-          "/lab/emoji-speaker.html",
-          "/lab/framer-loaders.html",
-          "/lab/google-loader.html",
-          "/lab/framer-flows.html",
-          "/lab/google-search-loader.html",
-          "/lab/framer-logo.html",
-          "/lab/figma-logo.html",
-          "/lab/buttons-custom-properties.html",
-          "/lab/checkout-tracking-card.html"
-        ],
-        "eagerness": "moderate"
-      }]
+      "prefetch": [
+        {
+          "source": "document",
+          "where": {
+            "selector_matches": ".demo-link"
+          },
+          "eagerness": "moderate"
+        }
+      ]
     }
   </script>
 </head>
@@ -98,11 +91,20 @@
   <main id="main-content" class="lab-container">
     <section class="demo-examples">
       <article tabindex="0" aria-label="Microsoft Logo Proto">
+        <a href="/lab/microsoft-logo.html" target="_blank" class="demo-link"
+          aria-label="Open Microsoft Logo Proto in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/microsoft-logo.html" title="Microsoft Logo Proto" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Headphones Knock">
         <a href="/lab/headphones.html" target="_blank" class="demo-link"
-          aria-label="Open Headphones Knock in a new tab">
+          aria-label="Open Headphones Knock in a new tab" rel="noopener noreferrer">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
             stroke-linecap="round" stroke-linejoin="round" class="external-icon">
             <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
@@ -113,31 +115,112 @@
         <iframe src="/lab/headphones.html" title="Headphones Knock" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Emoji Speaker Animation">
+        <a href="/lab/emoji-speaker.html" target="_blank" class="demo-link"
+          aria-label="Open Emoji Speaker Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/emoji-speaker.html" title="Emoji Speaker Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Framer Loaders Animation">
+        <a href="/lab/framer-loaders.html" target="_blank" class="demo-link"
+          aria-label="Open Framer Loaders Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/framer-loaders.html" title="Framer Loaders Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Google Loader Animation">
+        <a href="/lab/google-loader.html" target="_blank" class="demo-link"
+          aria-label="Open Google Loader Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/google-loader.html" title="Google Loader Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Framer Flows Animation">
+        <a href="/lab/framer-flows.html" target="_blank" class="demo-link"
+          aria-label="Open Framer Flows Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/framer-flows.html" title="Framer Flows Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Google Search Loader Animation">
+        <a href="/lab/google-search-loader.html" target="_blank" class="demo-link"
+          aria-label="Open Google Search Loader Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/google-search-loader.html" title="Google Search Loader Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Framer Logo Animation">
+        <a href="/lab/framer-logo.html" target="_blank" class="demo-link"
+          aria-label="Open Framer Logo Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/framer-logo.html" title="Framer Logo Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Figma Logo Animation">
+        <a href="/lab/figma-logo.html" target="_blank" class="demo-link"
+          aria-label="Open Figma Logo Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/figma-logo.html" title="Figma Logo Animation" loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Buttons with Custom Properties Animation">
+        <a href="/lab/buttons-custom-properties.html" target="_blank" class="demo-link"
+          aria-label="Open Buttons with Custom Properties Animation in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/buttons-custom-properties.html" title="Buttons with Custom Properties Animation"
           loading="lazy" fetchpriority="low"></iframe>
       </article>
       <article tabindex="0" aria-label="Google Store Checkout">
+        <a href="/lab/checkout-tracking-card.html" target="_blank" class="demo-link"
+          aria-label="Open Google Store Checkout in a new tab" rel="noopener noreferrer">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1"
+            stroke-linecap="round" stroke-linejoin="round" class="external-icon">
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+            <polyline points="15 3 21 3 21 9"></polyline>
+            <line x1="10" y1="14" x2="21" y2="3"></line>
+          </svg>
+        </a>
         <iframe src="/lab/checkout-tracking-card.html" title="Google Store Checkout" loading="lazy" fetchpriority="low"></iframe>
       </article>
     </section>


### PR DESCRIPTION
This change enhances the Lab page by adding external "Open in new tab" links to all demo articles, following the existing pattern. It also optimizes performance by implementing modern document-based Speculation Rules to prefetch these links on hover (moderate eagerness), replacing the previous hardcoded URL list.

---
*PR created automatically by Jules for task [3545109323773747282](https://jules.google.com/task/3545109323773747282) started by @rmjames*