### PR TITLE
Add back navigation links to lab experiments

### DIFF
--- a/lab/buttons-custom-properties.html
+++ b/lab/buttons-custom-properties.html
@@ -63,10 +63,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <button data-analytics-element="Enter Button">Enter</button>
     <button class="brown" data-analytics-element="Enter Button Brown">Enter</button>
 </body>

--- a/lab/checkout-tracking-card.html
+++ b/lab/checkout-tracking-card.html
@@ -302,10 +302,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <article class="tracking-card">
         <header class="card-header">
 

--- a/lab/emoji-speaker.html
+++ b/lab/emoji-speaker.html
@@ -108,10 +108,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <ul class='stack'>
         <li data-index='0'>🔈</li>
         <li data-index='.32'>🔉</li>

--- a/lab/figma-logo.html
+++ b/lab/figma-logo.html
@@ -70,10 +70,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <div class="icon">
         <div class="arc"></div>
         <div class="arc"></div>

--- a/lab/framer-flows.html
+++ b/lab/framer-flows.html
@@ -119,10 +119,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <div class="box">
         <div class="box-m"></div>
         <div class="box-s"></div>

--- a/lab/framer-loaders.html
+++ b/lab/framer-loaders.html
@@ -290,10 +290,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <div class="container">
         <div class='block'>
             <div class="half-circle"></div>

--- a/lab/framer-logo.html
+++ b/lab/framer-logo.html
@@ -73,10 +73,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <section class='icon'>
         <div class='polygon top'></div>
         <div class='polygon mid'></div>

--- a/lab/google-loader.html
+++ b/lab/google-loader.html
@@ -51,10 +51,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <div class="container"></div>
     <button class="reset-btn" data-analytics-element="Reset Animation" onclick="resetAnimation()">
         <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"

--- a/lab/google-search-loader.html
+++ b/lab/google-search-loader.html
@@ -374,10 +374,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <ul class="container">
         <li class="item"></li>
         <li class="item"></li>

--- a/lab/headphones.html
+++ b/lab/headphones.html
@@ -14,6 +14,7 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
     <style>
         body {
@@ -403,6 +404,13 @@
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <div class='headphone'>🎧</div>
     <div class='note'>🎶</div>
     <div class='notes'>🎶</div>

--- a/lab/microsoft-logo.html
+++ b/lab/microsoft-logo.html
@@ -115,10 +115,18 @@
     <link rel="icon" type="image/png" href="../favicon_512.png" sizes="512x512" />
     <link rel="icon" type="image/png" href="../favicon_192.png" sizes="192x192" />
     <link rel="manifest" href="../manifest.json" />
+    <link rel="stylesheet" href="../styles/lab-shared.css">
     <script src="../scripts/favicon-animator.js" async></script>
 </head>
 
 <body>
+    <a href="../lab.html" class="back-link" aria-label="Back to Labs">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m15 18-6-6 6-6" />
+        </svg>
+        <span>Back</span>
+    </a>
     <section>
         <div class="box toTop" style='--bg: hsl(13.1, 90.4%, 55.3%)'></div>
         <div class='box toRight' style='--bg: hsl(79.1, 93.8%, 38%)'></div>

--- a/styles/lab-shared.css
+++ b/styles/lab-shared.css
@@ -1,0 +1,65 @@
+.back-link {
+    position: fixed;
+    top: 1.25rem;
+    left: 1.25rem;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background: rgba(255, 255, 255, 0.7);
+    color: #1a1a1a;
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-radius: 100px;
+    text-decoration: none;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.875rem;
+    font-weight: 600;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+@media (prefers-color-scheme: dark) {
+    .back-link {
+        background: rgba(30, 30, 30, 0.7);
+        color: #f5f5f5;
+        border-color: rgba(255, 255, 255, 0.08);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    }
+}
+
+.back-link:hover {
+    transform: translateX(-4px);
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+}
+
+@media (prefers-color-scheme: dark) {
+    .back-link:hover {
+        background: rgba(50, 50, 50, 0.9);
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+    }
+}
+
+.back-link:active {
+    transform: translateX(-2px) scale(0.96);
+}
+
+.back-link svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+}
+
+@media (max-width: 480px) {
+    .back-link span {
+        display: none;
+    }
+    .back-link {
+        padding: 0.75rem;
+        top: 1rem;
+        left: 1rem;
+    }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const cacheName = 'v15'; // Bumped to v15 to cache lab subresources
+const cacheName = 'v16'; // Bumped to v16 to cache lab-shared.css
 const OFFLINE = 'offline.html';
 
 const assetsToCache = [
@@ -17,6 +17,7 @@ const assetsToCache = [
   '/lab/media-player.html',
   '/lab/microsoft-logo.html',
   '/styles/main.css',
+  '/styles/lab-shared.css',
   '/fonts/recursive-variable.woff2',
   '/images/icon.svg',
   '/images/icon-ios.svg',


### PR DESCRIPTION
This change adds a consistent "Back" navigation link to the top-left corner of the following lab experiments:
- microsoft-logo.html
- headphones.html
- emoji-speaker.html
- framer-loaders.html
- google-loader.html
- framer-flows.html
- google-search-loader.html
- framer-logo.html
- figma-logo.html
- buttons-custom-properties.html
- checkout-tracking-card.html

Key implementation details:
- Created `styles/lab-shared.css` for reusable navigation styling.
- The link uses `backdrop-filter: blur` for a polished look and supports light/dark modes for accessibility.
- The "Back" text automatically hides on very small screens to maintain layout integrity.
- Updated `sw.js` to include the new stylesheet in the precache list (version bumped to v16).
- Verified functionality and visual appearance via Playwright screenshots.

---
*PR created automatically by Jules for task [4737364900550783335](https://jules.google.com/task/4737364900550783335) started by @rmjames*