### PR TITLE
docs: Refine agent self-improvement loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ playwright-report/
 .dev.vars
 .wrangler/
 .env
+
+# Agent temporary workspace
+scratchpad.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - **Accessibility**: Use semantic HTML5 and follow best practices for interactive elements.
 
 ## Coding Style & Workflow
+- **Self-Improvement**: All agents must follow the workflow outlined in `SELF_IMPROVEMENT.md` (using `scratchpad.md` and `knowledge.md`) to plan tasks and retain knowledge.
 - **Tech Stack**: Use latest HTML5, CSS3, ESNext, TypeScript, and Node.js.
 - **Quality**: Write functional, composable, and stateful code. Avoid race conditions.
 - **Testing**: Run tests after every change and fix failures immediately.

--- a/SELF_IMPROVEMENT.md
+++ b/SELF_IMPROVEMENT.md
@@ -1,0 +1,32 @@
+# Agent Self-Improvement Loop
+
+To ensure continuous improvement and avoid repeating mistakes, all agents must follow this self-improvement loop when working on tasks.
+
+## 1. Planning and Task Breakdown (`scratchpad.md`)
+When given a new task, break it down before taking action.
+- Use a `scratchpad.md` file in the project root to plan your work. If it does not exist, create it.
+- **Clear or overwrite** previous contents of `scratchpad.md` at the start of a new task so you have a clean workspace.
+- Create a clear to-do list of the steps required to complete the task.
+- Use this scratchpad as your active workspace to track progress, note intermediate thoughts, and adjust your plan as needed.
+
+## 2. Referencing Past Knowledge (`knowledge.md`)
+Before starting execution on a prompt:
+- Always read `knowledge.md` in the project root. If it does not exist, create it.
+- Apply any relevant past learnings, rules, or insights to the current task to ensure previous mistakes are not repeated.
+
+## 3. Transferring Knowledge (`knowledge.md`)
+Once a task is completed and verified to work correctly, you must transfer any new, generalized, or project-specific working knowledge into `knowledge.md` in the project root.
+
+- **Append** your new learnings to the bottom of the file (do not overwrite the entire file).
+- **Check for redundancy**: Before adding a new entry, quickly scan `knowledge.md` to ensure a similar learning doesn't already exist. Only add genuinely new insights.
+
+Use the following strict format for all entries in `knowledge.md`:
+
+```markdown
+## [YYYY-MM-DD] - [Task Title]
+- **Context**: Brief context of the task and what was being attempted.
+- **Learning**: What worked, what failed, or specific knowledge gained about the codebase, environment, or tools.
+- **Action**: How to apply this specifically to future tasks.
+```
+
+By following this loop, you ensure that the system's collective intelligence grows with every completed task.


### PR DESCRIPTION
Refined the self-improvement loop implementation based on critical feedback.

- Added `scratchpad.md` to `.gitignore` to keep temporary task breakdowns out of version control.
- Updated `SELF_IMPROVEMENT.md` to explicitly state that agents must clear/overwrite `scratchpad.md` at the start of a task.
- Updated `SELF_IMPROVEMENT.md` to ensure agents *append* to `knowledge.md` and check for existing redundant information before adding.

---
*PR created automatically by Jules for task [13486767621564773920](https://jules.google.com/task/13486767621564773920) started by @rmjames*