### PR TITLE
Fix sed error in GitHub Actions and add HTML minification step

### DIFF
--- a/.github/workflows/minify-patterns.txt
+++ b/.github/workflows/minify-patterns.txt
@@ -1,9 +1,6 @@
 # HTML Link Replacement Patterns
-# Pattern 1: CSS links - avoid external URLs starting with http
-s/\(<link[^>]*href="\)\([^"]*[^/]\.css\)\("[^>]*>\)/\1\2.min\3/g
+# Pattern 1: CSS links - exclude http URLs
+/href="http/!s/\(<link[^>]*href="\)\([^"]*\)\.css\("\)/\1\2.min.css\3/g
 
-# Pattern 2: CSS links - exclude http URLs
-/href="http/!s/\(<link[^>]*href="\)\([^"]*\.css\)\("/\)/\1\2.min\3/g
-
-# Pattern 3: JS scripts - exclude http URLs
-/src="http/!s/\(<script[^>]*src="\)\([^"]*\.js\)\("/\)/\1\2.min\3/g
+# Pattern 2: JS scripts - exclude http URLs
+/src="http/!s/\(<script[^>]*src="\)\([^"]*\)\.js\("\)/\1\2.min.js\3/g

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -67,6 +67,9 @@ jobs:
           
           # Apply HTML replacement patterns
           find dist -type f -name "*.html" -exec sed -i -f .github/workflows/minify-patterns.txt {} +
+
+          # Minify HTML
+          npx html-minifier-terser --input-dir dist --output-dir dist --file-ext html --collapse-whitespace --remove-comments --minify-css true --minify-js true
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
This PR fixes a build failure on GitHub Actions where `sed` was failing due to an `unknown option to 's'` error, caused by improperly escaped slashes in `.github/workflows/minify-patterns.txt`. It properly corrects the replacements to ensure assets get mapped to `.min.css` and `.min.js`.

Additionally, per the requirement, this adds a new step utilizing `html-minifier-terser` to actually minify the generated HTML files themselves in the `dist` folder.

---
*PR created automatically by Jules for task [6838432299367197917](https://jules.google.com/task/6838432299367197917) started by @rmjames*