### PR TITLE
Fix Media Player Selector layout and native swiping

### DIFF
--- a/lab/media-player-selector.html
+++ b/lab/media-player-selector.html
@@ -55,13 +55,16 @@
 
         .carousel-view {
             display: flex;
+            flex-direction: row;
             align-items: center;
-            inline-size: 100%;
+            inline-size: 100vw;
             block-size: 100dvh;
             overflow-x: auto;
+            overflow-y: hidden;
             scroll-snap-type: x mandatory;
             scroll-behavior: smooth;
-            gap: 2rem;
+            gap: 1rem;
+            padding-inline: calc(50vw - 42.5vw); /* Centers an 85vw card perfectly */
             box-sizing: border-box;
             cursor: grab;
 
@@ -77,10 +80,10 @@
         .player-card {
             display: flex;
             flex-direction: column;
-            flex: 0 0 95vw;
+            flex: 0 0 85vw;
             position: relative;
-            block-size: 75dvh;
-            border-radius: 6rem;
+            block-size: 65dvh;
+            border-radius: 3rem;
             corner-shape: squircle;
             overflow: hidden;
             scroll-snap-align: center;

--- a/scripts/media/MediaPlayerSelector.js
+++ b/scripts/media/MediaPlayerSelector.js
@@ -29,6 +29,55 @@ if (carousel && pagination) {
         iframe.loading = 'lazy';
         card.appendChild(iframe);
 
+        // Create Interaction Overlay to handle swiping vs clicking
+        const overlay = document.createElement('div');
+        overlay.className = 'swipe-overlay';
+        overlay.style.position = 'absolute';
+        overlay.style.inset = '0';
+        overlay.style.zIndex = '10';
+        overlay.style.cursor = 'pointer';
+
+        let startX = 0;
+        let isSwiping = false;
+
+        overlay.addEventListener('touchstart', (e) => {
+            startX = e.touches[0].clientX;
+            isSwiping = false;
+        }, { passive: true });
+
+        overlay.addEventListener('touchmove', (e) => {
+            const currentX = e.touches[0].clientX;
+            if (Math.abs(startX - currentX) > 10) {
+                isSwiping = true;
+            }
+        }, { passive: true });
+
+        overlay.addEventListener('touchend', (e) => {
+            if (!isSwiping) {
+                // Tap detected, disable overlay to let clicks through to the iframe
+                overlay.style.pointerEvents = 'none';
+            } else {
+                // Swipe detected, scroll carousel programmatically
+                const endX = e.changedTouches[0].clientX;
+                const diff = startX - endX;
+                if (Math.abs(diff) > 30) {
+                    const direction = diff > 0 ? 1 : -1;
+                    carousel.scrollBy({ left: direction * window.innerWidth * 0.8, behavior: 'smooth' });
+                }
+            }
+        });
+
+        // Only show overlay on touch devices. For desktop mice, allow direct iframe interaction.
+        // We use a CSS media query check to see if the primary pointer is coarse (touch)
+        if (window.matchMedia("(pointer: coarse)").matches) {
+            card.appendChild(overlay);
+        } else {
+            // For desktop, disable overlay to allow immediate interaction without double clicking
+            overlay.style.pointerEvents = 'none';
+            overlay.style.display = 'none';
+            card.appendChild(overlay);
+        }
+
         carousel.appendChild(card);
 
         // Create Dot
@@ -46,4 +95,15 @@ if (carousel && pagination) {
         if (e.key === 'ArrowLeft') carousel.scrollBy({ left: -window.innerWidth * 0.8, behavior: 'smooth' });
         if (e.key === 'ArrowRight') carousel.scrollBy({ left: window.innerWidth * 0.8, behavior: 'smooth' });
     });
+
+    // Reset interaction overlays when carousel scrolls
+    let scrollTimeout;
+    carousel.addEventListener('scroll', () => {
+        clearTimeout(scrollTimeout);
+        scrollTimeout = setTimeout(() => {
+            document.querySelectorAll('.swipe-overlay').forEach(overlay => {
+                overlay.style.pointerEvents = 'auto';
+            });
+        }, 150);
+    }, { passive: true });
 }

--- a/scripts/media/MediaPlayerSelector.js
+++ b/scripts/media/MediaPlayerSelector.js
@@ -29,55 +29,6 @@ if (carousel && pagination) {
         iframe.loading = 'lazy';
         card.appendChild(iframe);
 
-        // Create Interaction Overlay to handle swiping vs clicking
-        const overlay = document.createElement('div');
-        overlay.className = 'swipe-overlay';
-        overlay.style.position = 'absolute';
-        overlay.style.inset = '0';
-        overlay.style.zIndex = '10';
-        overlay.style.cursor = 'pointer';
-
-        let startX = 0;
-        let isSwiping = false;
-
-        overlay.addEventListener('touchstart', (e) => {
-            startX = e.touches[0].clientX;
-            isSwiping = false;
-        }, { passive: true });
-
-        overlay.addEventListener('touchmove', (e) => {
-            const currentX = e.touches[0].clientX;
-            if (Math.abs(startX - currentX) > 10) {
-                isSwiping = true;
-            }
-        }, { passive: true });
-
-        overlay.addEventListener('touchend', (e) => {
-            if (!isSwiping) {
-                // Tap detected, disable overlay to let clicks through to the iframe
-                overlay.style.pointerEvents = 'none';
-            } else {
-                // Swipe detected, scroll carousel programmatically
-                const endX = e.changedTouches[0].clientX;
-                const diff = startX - endX;
-                if (Math.abs(diff) > 30) {
-                    const direction = diff > 0 ? 1 : -1;
-                    carousel.scrollBy({ left: direction * window.innerWidth * 0.8, behavior: 'smooth' });
-                }
-            }
-        });
-
-        // Only show overlay on touch devices. For desktop mice, allow direct iframe interaction.
-        // We use a CSS media query check to see if the primary pointer is coarse (touch)
-        if (window.matchMedia("(pointer: coarse)").matches) {
-            card.appendChild(overlay);
-        } else {
-            // For desktop, disable overlay to allow immediate interaction without double clicking
-            overlay.style.pointerEvents = 'none';
-            overlay.style.display = 'none';
-            card.appendChild(overlay);
-        }
-
         carousel.appendChild(card);
 
         // Create Dot
@@ -95,15 +46,4 @@ if (carousel && pagination) {
         if (e.key === 'ArrowLeft') carousel.scrollBy({ left: -window.innerWidth * 0.8, behavior: 'smooth' });
         if (e.key === 'ArrowRight') carousel.scrollBy({ left: window.innerWidth * 0.8, behavior: 'smooth' });
     });
-
-    // Reset interaction overlays when carousel scrolls
-    let scrollTimeout;
-    carousel.addEventListener('scroll', () => {
-        clearTimeout(scrollTimeout);
-        scrollTimeout = setTimeout(() => {
-            document.querySelectorAll('.swipe-overlay').forEach(overlay => {
-                overlay.style.pointerEvents = 'auto';
-            });
-        }, 150);
-    }, { passive: true });
 }


### PR DESCRIPTION
Fixes the Media Player Selector layout which previously caused the `player-cards` to stack visually on mobile devices. By enforcing a horizontal flex layout and adding inline padding, the carousel now correctly centers the active 85vw card and allows adjacent cards to peek in. This resolves the native swiping issue without needing complex JS overlays, relying instead on clean native CSS scroll-snapping over the exposed gaps.

---
*PR created automatically by Jules for task [14873322377950237198](https://jules.google.com/task/14873322377950237198) started by @rmjames*