### PR TITLE
⚡ Bolt: Optimize Analytics Hover Tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2025-05-27 - [IntersectionObserver Memory Leak Prevention]
 **Learning:** When using `IntersectionObserver` for one-time actions (like lazy-loading an iframe or initializing tracking), failing to call `unobserve()` leaves the observer active, causing unnecessary callback triggers on every scroll event that intersects the element. This wastes CPU cycles.
 **Action:** Always pass the observer instance (usually `obs` as the second argument to the callback) and call `obs.unobserve(entry.target)` immediately after the initial condition is met. Ensure unit tests mocking `IntersectionObserver` pass `this` to the callback to correctly test `unobserve()` behavior.
+## 2025-05-27 - [Event Delegation Anti-Pattern]
+**Learning:** Using global event delegation (`document.addEventListener`) for high-frequency events like `mouseover` or `mousemove` causes extreme main-thread bloat, as the listener evaluates logic (like `.closest()`) on every single DOM boundary crossed by the mouse.
+**Action:** Avoid global event delegation for high-frequency events. Instead, explicitly attach `mouseenter` or `mouseleave` listeners directly to the specific elements that require tracking, ensuring the callbacks only fire when interacting with the intended targets.

--- a/scripts/analytics.js
+++ b/scripts/analytics.js
@@ -88,14 +88,13 @@ export function initAnalytics() {
     }
   });
 
-  // Performance optimization: Use event delegation on document instead of
-  // attaching individual listeners to potentially many elements.
-
-  // Track hovers via event delegation (mouseover to mimic mouseenter)
-  document.addEventListener("mouseover", (event) => {
-    // Links hover
-    const link = event.target.closest && event.target.closest("[data-analytics-link]");
-    if (link && !link.contains(event.relatedTarget)) {
+  // Performance optimization (PERF-XX): Avoid global mouseover event delegation.
+  // Listening to 'mouseover' on the document causes event.target.closest() to be
+  // evaluated on almost every mouse movement, blocking the main thread.
+  // Instead, attach 'mouseenter' directly to the elements we want to track.
+  const analyticsLinks = document.querySelectorAll("[data-analytics-link]");
+  analyticsLinks.forEach((link) => {
+    link.addEventListener("mouseenter", () => {
       const linkName = link.dataset.analyticsLink;
       const eventData = {
         event_category: "Link Hover",
@@ -103,18 +102,19 @@ export function initAnalytics() {
         non_interaction: true,
       };
       gtag("event", "mouseover", eventData);
-    }
+    });
+  });
 
-    // Brand hover
-    const brand = event.target.closest && event.target.closest(".brand");
-    if (brand && !brand.contains(event.relatedTarget)) {
+  const brands = document.querySelectorAll(".brand");
+  brands.forEach((brand) => {
+    brand.addEventListener("mouseenter", () => {
       const eventData = {
         event_category: "Brand Interaction",
         event_label: `Hover - ${brand.textContent.trim()}`,
         non_interaction: true,
       };
       gtag("event", "mouseover", eventData);
-    }
+    });
   });
 
   // Track toggle events via event delegation (capturing phase because toggle doesn't bubble)

--- a/scripts/test/analytics.test.js
+++ b/scripts/test/analytics.test.js
@@ -109,7 +109,7 @@ describe('analytics.js', () => {
 
   it('should track custom data-analytics-link hover', () => {
     const link = document.querySelector('[data-analytics-link]');
-    const event = new MouseEvent('mouseover', { bubbles: true });
+    const event = new MouseEvent('mouseenter', { bubbles: true });
     link.dispatchEvent(event);
 
     expect(global.gtag).toHaveBeenCalledWith('event', 'mouseover', {
@@ -125,6 +125,18 @@ describe('analytics.js', () => {
       event_category: 'Brand Interaction',
       event_label: 'Click - SBE',
       transport_type: 'beacon',
+    });
+  });
+
+  it('should track brand interaction hover', () => {
+    const brand = document.querySelector('.brand');
+    const event = new MouseEvent('mouseenter', { bubbles: true });
+    brand.dispatchEvent(event);
+
+    expect(global.gtag).toHaveBeenCalledWith('event', 'mouseover', {
+      event_category: 'Brand Interaction',
+      event_label: 'Hover - SBE',
+      non_interaction: true,
     });
   });
 


### PR DESCRIPTION
⚡ Bolt: Remove global `mouseover` event delegation for analytics

💡 What: Replaced global `document.addEventListener('mouseover')` with direct `mouseenter` attachments on `[data-analytics-link]` and `.brand` elements.
🎯 Why: Listening to `mouseover` on the document triggers callback logic (including `element.closest()`) for nearly every mouse movement across any element on the page, blocking the main thread and causing UI jank.
📊 Impact: Eliminates continuous background CPU usage during normal mouse movement, firing tracking logic *only* when the user interacts with the targeted elements.
🔬 Measurement: Verify using Chrome DevTools Performance Profiler; observe a significant drop in "Event: mouseover" scripting time during general page interaction.

---
*PR created automatically by Jules for task [13805498182935072775](https://jules.google.com/task/13805498182935072775) started by @rmjames*