### PR TITLE
feat: Upgrade Equalizer to 10 Bands with Smooth -20dB Range

### DIFF
--- a/scripts/media/Constants.js
+++ b/scripts/media/Constants.js
@@ -6,9 +6,14 @@ export const SVG_PATHS = {
 };
 
 export const EQ_CONFIG = [
-    { label: '50Hz', freq: 40, type: 'lowshelf' },
-    { label: '230Hz', freq: 230, type: 'peaking' },
-    { label: '910Hz', freq: 910, type: 'peaking' },
+    { label: '32Hz', freq: 32, type: 'lowshelf' },
+    { label: '64Hz', freq: 64, type: 'peaking' },
+    { label: '128Hz', freq: 128, type: 'peaking' },
+    { label: '256Hz', freq: 256, type: 'peaking' },
+    { label: '512Hz', freq: 512, type: 'peaking' },
+    { label: '1kHz', freq: 1000, type: 'peaking' },
+    { label: '2kHz', freq: 2000, type: 'peaking' },
     { label: '4kHz', freq: 4000, type: 'peaking' },
-    { label: '12kHz', freq: 12000, type: 'highshelf' }
+    { label: '8kHz', freq: 8000, type: 'peaking' },
+    { label: '16kHz', freq: 16000, type: 'highshelf' }
 ];

--- a/scripts/media/EqualizerUI.js
+++ b/scripts/media/EqualizerUI.js
@@ -65,7 +65,7 @@ export class EqualizerUI {
                     <div class="eq-slider__track"></div>
                     <div class="eq-slider__fill"></div>
                     <div class="eq-slider__thumb"></div>
-                    <input type="range" min="-12" max="12" value="0" step="0.1" aria-label="${config.label}">
+                    <input type="range" min="-20" max="20" value="0" step="0.1" aria-label="${config.label}">
                 </div>
                 <span class="eq-slider__label">${config.label}</span>
             `;

--- a/styles/components/media-player.css
+++ b/styles/components/media-player.css
@@ -287,7 +287,7 @@ body {
 .eq-grid {
     flex: 1;
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(10, 1fr);
     gap: 0.25rem;
     align-items: center;
     justify-items: center;


### PR DESCRIPTION
Updates the equalizer component to support a professional 10-band configuration. 

Changes:
- **`EQ_CONFIG`:** Expanded from 5 bands to 10 bands (32Hz, 64Hz, 128Hz, 256Hz, 512Hz, 1kHz, 2kHz, 4kHz, 8kHz, 16kHz). Assigned `lowshelf` to 32Hz and `highshelf` to 16kHz, with intermediate frequencies configured as `peaking`.
- **`EqualizerUI`:** Updated the slider input range configuration to expand from `[-12, 12]` to a smoother `[-20, 20]` range with `0.1` steps.
- **CSS Grid:** Modified the grid layout in `media-player.css` to properly repeat 10 columns instead of 5, supporting the new visual structure.

---
*PR created automatically by Jules for task [11480090973818853176](https://jules.google.com/task/11480090973818853176) started by @rmjames*