### PR TITLE
feat: Add mobile touch support for long press actions in media players

### DIFF
--- a/lab/media-player-inline.html
+++ b/lab/media-player-inline.html
@@ -238,35 +238,14 @@
             console.log('Mode switched to:', currentMode);
         };
 
-        optionBtn.addEventListener('mousedown', () => {
-            longPressTimer = setTimeout(() => {
-                onLongPress();
-                longPressTimer = null;
-            }, LONG_PRESS_MS);
-        });
-
-        window.addEventListener('mouseup', () => {
-            if (longPressTimer) {
-                clearTimeout(longPressTimer);
-                longPressTimer = null;
+        UI.setupLongPress(optionBtn, {
+            onShortPress: () => {
                 handleOptionClick();
-            }
-        });
-
-        optionBtn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            longPressTimer = setTimeout(() => {
+            },
+            onLongPress: () => {
                 onLongPress();
-                longPressTimer = null;
-            }, LONG_PRESS_MS);
-        }, { passive: false });
-
-        optionBtn.addEventListener('touchend', () => {
-            if (longPressTimer) {
-                clearTimeout(longPressTimer);
-                longPressTimer = null;
-                handleOptionClick();
-            }
+            },
+            delay: LONG_PRESS_MS
         });
     </script>
 </body>

--- a/lab/media-player.html
+++ b/lab/media-player.html
@@ -239,24 +239,15 @@
             }
         };
 
-        let longPressTimer;
-        let longPressTriggered = false;
-
-        optionButton.addEventListener('mousedown', () => {
-            longPressTriggered = false;
-            longPressTimer = setTimeout(() => {
-                longPressTriggered = true;
+        UI.setupLongPress(optionButton, {
+            onShortPress: () => {
+                handleOptionClick();
+            },
+            onLongPress: () => {
                 optionButton.classList.add('animate-outline');
                 toggleMode();
-            }, 500);
-        });
-
-        const stopOptionPress = () => clearTimeout(longPressTimer);
-        ['mouseup', 'mouseleave', 'touchend'].forEach(evt => optionButton.addEventListener(evt, stopOptionPress));
-
-        optionButton.addEventListener('click', () => {
-            if (longPressTriggered) return;
-            handleOptionClick();
+            },
+            delay: 500
         });
 
         // --- Presets & Popover ---

--- a/scripts/media/MediaPlayerUI.js
+++ b/scripts/media/MediaPlayerUI.js
@@ -173,5 +173,66 @@ export const UI = {
         if (!element || !track || !cssVarName) return;
         const color = await ColorExtractor.getAccentColor(track.albumArt);
         element.style.setProperty(cssVarName, color);
+    },
+
+    setupLongPress(button, { onShortPress, onLongPress, delay = 500 }) {
+        if (!button) return;
+
+        let longPressTimer;
+        let longPressTriggered = false;
+
+        const startPress = (e) => {
+            if (e.type === 'touchstart') {
+                // We might not want to prevent default globally, but for a long press button it might be needed.
+                // However, doing so can break scrolling if the button is inside a scrollable container.
+                // We will leave preventDefault up to the caller or allow passive listeners.
+            }
+            longPressTriggered = false;
+            longPressTimer = setTimeout(() => {
+                longPressTriggered = true;
+                if (onLongPress) onLongPress(e);
+                longPressTimer = null;
+            }, delay);
+        };
+
+        const cancelPress = () => {
+            if (longPressTimer) {
+                clearTimeout(longPressTimer);
+                longPressTimer = null;
+            }
+        };
+
+        const handleShortPress = (e) => {
+            cancelPress();
+            if (!longPressTriggered && onShortPress) {
+                onShortPress(e);
+            }
+        };
+
+        // Mouse events
+        button.addEventListener('mousedown', startPress);
+        button.addEventListener('mouseleave', cancelPress);
+        button.addEventListener('mouseup', handleShortPress);
+
+        // Touch events
+        button.addEventListener('touchstart', startPress, { passive: true });
+        button.addEventListener('touchmove', cancelPress, { passive: true }); // Cancel on scroll
+        button.addEventListener('touchend', handleShortPress);
+
+        // Disable context menu on long press for mobile
+        button.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
+        });
+
+        // Cleanup function
+        return () => {
+            button.removeEventListener('mousedown', startPress);
+            button.removeEventListener('mouseleave', cancelPress);
+            button.removeEventListener('mouseup', handleShortPress);
+            button.removeEventListener('touchstart', startPress);
+            button.removeEventListener('touchmove', cancelPress);
+            button.removeEventListener('touchend', handleShortPress);
+            button.removeEventListener('contextmenu', e => e.preventDefault());
+        };
     }
 };


### PR DESCRIPTION
Abstracts long press logic into a generic utility in the `MediaPlayerUI` module. This ensures that touch devices can effectively interact with components relying on long-press inputs (e.g. toggling modes on the media player option button), which previously only supported mouse events (`mousedown`, etc) in the primary media player lab implementation.

---
*PR created automatically by Jules for task [160004226149089924](https://jules.google.com/task/160004226149089924) started by @rmjames*