### PR TITLE
Make Media Player Equalizer Container-Responsive and Scrollable

### DIFF
--- a/lab/media-player-lock-screen.html
+++ b/lab/media-player-lock-screen.html
@@ -44,6 +44,7 @@
         }
 
         .media-player__equalizer {
+            container-type: size;
             position: absolute;
             inset: 0;
             background: oklch(from #1a1a1a l c h / 0.9);
@@ -107,6 +108,17 @@
             gap: 0.5rem;
             align-items: stretch;
             min-height: 0;
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+
+        .eq-grid::-webkit-scrollbar {
+            width: 4px;
+        }
+
+        .eq-grid::-webkit-scrollbar-thumb {
+            background: oklch(from #555 l c h);
+            border-radius: 4px;
         }
 
         .media-player__equalizer__slider {
@@ -115,6 +127,18 @@
             flex-direction: column;
             align-items: center;
             gap: 0.5rem;
+        }
+
+        @container (max-height: 250px) {
+            .media-player__equalizer__slider {
+                min-height: 120px;
+            }
+            .eq-header h3 {
+                font-size: 1rem;
+            }
+            .eq-grid {
+                gap: 0.25rem;
+            }
         }
 
         .media-player-grid__row {

--- a/styles/components/media-player.css
+++ b/styles/components/media-player.css
@@ -211,8 +211,10 @@ body {
 
 /* Equalizer Interface */
 .media-player__equalizer {
+    container-type: size;
     position: absolute;
     inset: 0;
+    background: #333;
     background: oklch(from #333 l c h);
     border-radius: inherit;
     padding: 1rem;
@@ -224,7 +226,7 @@ body {
     pointer-events: none;
     transform: translateY(10px);
     transition: opacity 0.2s ease, transform 0.2s ease;
-    z-index: 10;
+    z-index: 100;
 }
 
 .media-player__equalizer.active {
@@ -261,6 +263,19 @@ body {
     justify-content: space-between;
     align-items: center;
     padding: 0.5rem 0;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+.eq-sidebar::-webkit-scrollbar {
+    display: none;
+}
+
+#eq-close-btn {
+    position: sticky;
+    top: 0;
+    background: oklch(from #333 l c h) !important;
+    z-index: 2;
 }
 
 .eq-sidebar__btn {
@@ -291,6 +306,18 @@ body {
     gap: 0.25rem;
     align-items: center;
     justify-items: center;
+    overflow-y: auto;
+    overflow-x: hidden;
+    min-height: 0;
+}
+
+.eq-grid::-webkit-scrollbar {
+    width: 4px;
+}
+
+.eq-grid::-webkit-scrollbar-thumb {
+    background: oklch(from #555 l c h);
+    border-radius: 4px;
 }
 
 .media-player__equalizer__slider {
@@ -345,6 +372,21 @@ body {
     transform: translate(-50%, -50%);
     left: 50%;
     pointer-events: none;
+}
+
+@container (max-height: 250px) {
+    .media-player__equalizer__slider {
+        min-height: 120px;
+    }
+
+    .eq-sidebar {
+        justify-content: flex-start;
+        gap: 1rem;
+    }
+
+    .eq-grid {
+        gap: 0.125rem;
+    }
 }
 
 /* --- Preset Popover/Tooltip --- */


### PR DESCRIPTION
Resolves an issue where the new Equalizer component's vertical sliders would overflow bounds ungracefully in tight widget and mobile layouts, occasionally rendering the close toggle inaccessible. Implemented CSS container queries allowing internal sliders to shrink to minimal functional heights before transitioning to smooth `overflow-y` scrolling, whilst perpetually pinning the Close overlay fixed to the panel's absolute top-edge.

---
*PR created automatically by Jules for task [6273807749814918706](https://jules.google.com/task/6273807749814918706) started by @rmjames*