### PR TITLE
⚡ Bolt: Prevent layout thrashing in MediaPlayerUI.updateMarquee

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2025-05-27 - [Event Delegation Anti-Pattern]
 **Learning:** Using global event delegation (`document.addEventListener`) for high-frequency events like `mouseover` or `mousemove` causes extreme main-thread bloat, as the listener evaluates logic (like `.closest()`) on every single DOM boundary crossed by the mouse.
 **Action:** Avoid global event delegation for high-frequency events. Instead, explicitly attach `mouseenter` or `mouseleave` listeners directly to the specific elements that require tracking, ensuring the callbacks only fire when interacting with the intended targets.
+## 2025-05-27 - [Layout Thrashing Prevention in Marquee Updates]
+**Learning:** Sequential DOM reads and writes in the same animation frame (e.g. `clientWidth` followed by `classList.add`) cause layout thrashing (forced synchronous layout). This was happening in `MediaPlayerUI.updateMarquee` when it was called multiple times in rapid succession (e.g. for both title and artist elements).
+**Action:** Always batch DOM reads and writes. A simple way to do this when updating multiple elements is the double `requestAnimationFrame` pattern: perform DOM reads in the first frame, and defer the DOM writes to a nested `requestAnimationFrame` callback.

--- a/scripts/media/MediaPlayerUI.js
+++ b/scripts/media/MediaPlayerUI.js
@@ -31,17 +31,21 @@ export const UI = {
 
         // Defer reads and writes to avoid layout thrashing during track changes
         requestAnimationFrame(() => {
+            // DOM READ phase
             // Use cached width if available to avoid clientWidth read
             const parentWidth = this._parentWidths.get(el) || el.clientWidth;
             const textWidth = el.scrollWidth;
 
-            if (textWidth > parentWidth) {
-                el.classList.add('is-marquee');
-                el.style.setProperty('--marquee-width', `${parentWidth}px`);
-            } else {
-                el.classList.remove('is-marquee');
-                el.style.setProperty('--marquee-width', '0px');
-            }
+            // DOM WRITE phase (deferred to next frame to prevent forced synchronous layout)
+            requestAnimationFrame(() => {
+                if (textWidth > parentWidth) {
+                    el.classList.add('is-marquee');
+                    el.style.setProperty('--marquee-width', `${parentWidth}px`);
+                } else {
+                    el.classList.remove('is-marquee');
+                    el.style.setProperty('--marquee-width', '0px');
+                }
+            });
         });
     },
 


### PR DESCRIPTION
💡 **What**: Refactored `MediaPlayerUI.updateMarquee` to batch DOM reads and writes using a double `requestAnimationFrame` pattern.
🎯 **Why**: When `updateMarquee` was called sequentially (e.g., for title and artist), reading dimensions (`clientWidth`, `scrollWidth`) immediately after modifying classes (`classList.add`) caused layout thrashing (forced synchronous layout), blocking the main thread during rapid DOM updates.
📊 **Impact**: Eliminates forced synchronous layout during track changes and window resizing, improving frame rates and responsiveness of the media player UI.
🔬 **Measurement**: Verified by running unit tests (`pnpm test`) and confirming UI updates do not trigger "Forced reflow" warnings in Chrome DevTools Performance profiles. Also recorded this learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [10484131310811220103](https://jules.google.com/task/10484131310811220103) started by @rmjames*