### PR TITLE
refactor(lab): Move ConfigPanelManager to scripts/utils

### DIFF
--- a/control-panel.md
+++ b/control-panel.md
@@ -1,0 +1,85 @@
+# Component Control Panel Documentation
+
+## Overview
+
+The `lab/components.html` environment includes a dynamic, native configuration control panel built into the UI components. This allows developers and designers to interactively adjust and test common CSS layout properties, typography, and colors directly in the browser.
+
+The primary goal of this tool is to stress-test layout robustness, specifically observing how nested components react to **CSS Container Queries** (`container-type: inline-size`) when their parent wrapper is resized.
+
+## Architecture & Implementation
+
+The control panel avoids external UI libraries, instead leveraging modern HTML and JS standards for a lightweight implementation.
+
+### Native HTML Popover API
+The panel utilizes the native HTML `<div popover="auto">` API.
+- **Benefits:** It automatically handles top-layer positioning (preventing z-index collisions), light dismiss (clicking outside to close), and keyboard accessibility (ESC to close) without complex Javascript.
+- **Trigger:** A "..." SVG icon button dynamically injected into the `.component-wrapper` acts as the trigger via `popovertarget="config-popover-{index}"`.
+
+### 3-Column Layout UI
+The internal controls follow a clean, developer-tools inspired 3-column layout utilizing CSS Grid:
+```css
+.config-control-group {
+    display: grid;
+    grid-template-columns: 1.5fr 2fr 1fr; /* [Label] [Input/Select] [Live Value] */
+}
+```
+1. **Property Name:** A clear `<label>` describing the property.
+2. **Control Tool:** The input element (`<input type="range">`, `<select>`, `<input type="text">`).
+3. **Current Value:** A read-only `<span>` that updates in real-time as the control is manipulated.
+
+### Visual Focus State (Dim & Blur)
+To enhance usability, the UI employs a focus state when a configuration panel is active.
+- **Active Component:** The component being configured receives an `.is-configuring` class, applying an outline (`var(--orange-3)`).
+- **Background Components:** The parent `.components-grid` receives a `.has-active-config` class. CSS is used to gracefully fade (`opacity: 0.4`) and blur (`filter: blur(4px)`) all other `.component-wrapper` elements that are *not* currently active, keeping the user's focus locked on their task.
+- **State Management:** This logic is handled strictly through the native `toggle` event listener attached to the popover element, ensuring states accurately reflect the open/closed status.
+
+### Theming & Design Tokens
+The control panel heavily utilizes established CSS custom properties from `styles/main.css`.
+- **Colors:** Fallback colors and predefined color selections (e.g., Background Color, Text Color) strictly utilize the `oklch` color space format tied to project design tokens (e.g., `var(--black-3)`, `var(--white-1)`).
+- **Light/Dark Mode:** The popover UI utilizes media queries (`@media (prefers-color-scheme: light)`) to adapt flawlessly to the system theme setting, switching background surfaces and border opacities accordingly.
+
+## Available Controls
+
+The JavaScript iterates over an array of control definitions, dynamically generating the DOM for each. Currently supported controls include:
+
+| Property Name | Control Type | Maps to CSS Property | Default Example |
+| :--- | :--- | :--- | :--- |
+| **Inline Size (Width)** | Range Slider | `width` | Dynamically captured (`offsetWidth`) |
+| **Block Size (Height)** | Range Slider | `height` | Dynamically captured (`offsetHeight`) |
+| **Border Radius** | Range Slider | `border-radius` | `24px` |
+| **Padding** | Range Slider | `padding` | `24px` |
+| **Font Size** | Range Slider | `font-size` | `16px` |
+| **Background Color** | Select Dropdown | `background-color` | `Default` (Tokens: Black-1, White-1, etc.) |
+| **Text/Icon Color** | Select Dropdown | `color` | `Default` (Tokens: Gray-1, Orange-2, etc.) |
+| **Font Family** | Select Dropdown | `font-family` | System Default, Arial, Courier New |
+| **Display** | Select Dropdown | `display` | `flex`, `block`, `grid`, `inline-block` |
+| **Transform** | Text Input | `transform` | `e.g., scale(0.9)` |
+| **Transition** | Text Input | `transition` | `e.g., all 0.3s ease` |
+
+## Refactoring for Element Agnosticism
+
+While the initial implementation targets specific classes (`.component-wrapper` and `.components-grid`) in `lab/components.html`, the core logic is highly adaptable. To make this implementation entirely agnostic to any element or container across the project, it should be refactored into a reusable Factory Class (e.g., `ConfigPanelManager`).
+
+### Proposed Agnostic Architecture
+
+1. **Target Injection via Parameters:**
+   Instead of hardcoding a `document.querySelectorAll()` loop over a specific class, the initialization function should accept specific nodes.
+   ```javascript
+   const panel = new ConfigPanelManager({
+       target: document.getElementById('my-hero-section'), // The element being styled
+       container: document.querySelector('main') // The scope for the dim/blur effect
+   });
+   ```
+
+2. **Dynamic Control Schemas:**
+   Different elements require different controls (e.g., an image doesn't need font controls). The configuration array should be passed in at initialization rather than hardcoded in the loop.
+   ```javascript
+   const textSchema = [
+       { label: 'Font Size', type: 'range', property: 'fontSize', min: 10, max: 72, unit: 'px' },
+       { label: 'Color', type: 'select', property: 'color', options: ['var(--white-1)', 'var(--black-1)'] }
+   ];
+   ```
+
+3. **Event-Driven State Management:**
+   To decouple the JavaScript from the CSS logic, the `toggle` listener shouldn't hardcode classes like `.is-configuring` or `.has-active-config`. Instead, it should dispatch `CustomEvent` objects (`config-open` and `config-close`) on the target element.
+   The consuming HTML page or a broader layout manager can then listen for these events and apply whatever CSS classes it deems appropriate for outlines and blurring.

--- a/lab/components.html
+++ b/lab/components.html
@@ -117,6 +117,166 @@
             font-size: 1.25rem;
             font-weight: 600;
         }
+
+        /* Configuration Controls Styles */
+        .component-wrapper {
+            position: relative; /* For positioning the controls button */
+            transition: outline 0.2s ease, opacity 0.3s ease, filter 0.3s ease;
+        }
+
+        .component-wrapper.is-configuring {
+            outline: 2px solid var(--orange-3);
+        }
+
+        .components-grid.has-active-config .component-wrapper:not(.is-configuring) {
+            opacity: 0.4;
+            filter: blur(4px);
+            pointer-events: none;
+        }
+
+        .config-btn {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: transparent;
+            border: none;
+            color: var(--text-color, oklch(from #e3e3e3 l c h));
+            cursor: pointer;
+            padding: 0.25rem;
+            border-radius: 50%;
+            display: grid;
+            place-items: center;
+            opacity: 0.5;
+            transition: opacity 0.2s ease, background 0.2s ease;
+            z-index: 10;
+        }
+
+        .config-btn:hover {
+            opacity: 1;
+            background: oklch(1 0 0 / 0.1);
+        }
+
+        .config-popover {
+            padding: 1.5rem;
+            border-radius: 1rem;
+            background: var(--bg-surface, oklch(from #1a1a1a l c h));
+            border: 1px solid var(--border-color, oklch(1 0 0 / 0.1));
+            color: var(--text-color, oklch(from #e3e3e3 l c h));
+            box-shadow: 0 8px 24px oklch(0 0 0 / 0.3);
+            margin: auto;
+            max-width: 90vw;
+            width: max-content;
+            min-width: 400px;
+        }
+
+        .config-popover::backdrop {
+            background: oklch(0 0 0 / 0.5);
+            backdrop-filter: blur(2px);
+        }
+
+        @media (prefers-color-scheme: light) {
+            .config-popover {
+                background: var(--bg-surface, oklch(from #ffffff l c h));
+                border: 1px solid var(--border-color, oklch(0 0 0 / 0.1));
+                color: var(--text-color, oklch(from #333 l c h));
+            }
+            .config-popover::backdrop {
+                background: oklch(0 0 0 / 0.2);
+            }
+            .config-btn {
+                color: var(--text-color, oklch(from #333 l c h));
+            }
+            .config-btn:hover {
+                background: oklch(0 0 0 / 0.1);
+            }
+        }
+
+        .config-popover-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid var(--border-color, oklch(1 0 0 / 0.1));
+        }
+
+        .config-popover-header h4 {
+            margin: 0;
+            font-size: 1.1rem;
+        }
+
+        .config-popover-close {
+            background: transparent;
+            border: none;
+            color: inherit;
+            cursor: pointer;
+            padding: 0.25rem;
+            display: grid;
+            place-items: center;
+            border-radius: 50%;
+        }
+
+        .config-popover-close:hover {
+            background: oklch(1 0 0 / 0.1);
+        }
+
+        .config-control-group {
+            display: grid;
+            grid-template-columns: 1.5fr 2fr 1fr;
+            gap: 1rem;
+            align-items: center;
+            margin-bottom: 0.75rem;
+            font-family: var(--font-stack);
+        }
+
+        .config-control-group:last-child {
+            margin-bottom: 0;
+        }
+
+        .config-control-group label {
+            font-size: 0.85rem;
+            opacity: 0.9;
+        }
+
+        .config-control-value {
+            font-size: 0.85rem;
+            font-family: "Courier New", monospace;
+            color: var(--gray-1);
+            text-align: right;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .config-control-group input[type="range"] {
+            width: 100%;
+        }
+
+        .config-control-group select,
+        .config-control-group input[type="text"] {
+            width: 100%;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.25rem;
+            border: 1px solid var(--border-color, oklch(1 0 0 / 0.2));
+            background: var(--bg-surface, oklch(0 0 0 / 0.2));
+            color: inherit;
+            font-family: inherit;
+            font-size: 0.85rem;
+        }
+
+        @media (prefers-color-scheme: light) {
+            .config-control-group select,
+            .config-control-group input[type="text"] {
+                border: 1px solid var(--border-color, oklch(0 0 0 / 0.2));
+                background: var(--bg-surface, oklch(1 0 0 / 0.5));
+            }
+            .config-popover-header {
+                border-bottom: 1px solid var(--border-color, oklch(0 0 0 / 0.1));
+            }
+            .config-popover-close:hover {
+                background: oklch(0 0 0 / 0.1);
+            }
+        }
     </style>
 </head>
 <body>
@@ -255,6 +415,7 @@
         import { EqualizerUI } from '../scripts/media/EqualizerUI.js';
         import { UI } from '../scripts/media/MediaPlayerUI.js';
         import { SVG_PATHS } from '../scripts/media/Constants.js';
+        import { ConfigPanelManager } from '../scripts/utils/ConfigPanelManager.js';
 
         const audio = document.getElementById('audio-player');
         const core = new MediaPlayerCore(audio);
@@ -420,6 +581,117 @@
             fragment.appendChild(btn);
         });
         presetsContainer.appendChild(fragment);
+
+        // --- Configuration Controls Setup ---
+        const componentWrappers = document.querySelectorAll('.component-wrapper');
+
+        const labControlSchema = [
+            {
+                label: 'Inline Size (Width)',
+                type: 'range',
+                property: 'width',
+                min: 100, max: 800,
+                value: (target) => target.offsetWidth,
+                unit: 'px',
+                onChange: (val, target) => target.style.width = `${val}px`
+            },
+            {
+                label: 'Block Size (Height)',
+                type: 'range',
+                property: 'height',
+                min: 50, max: 600,
+                value: (target) => target.offsetHeight,
+                unit: 'px',
+                onChange: (val, target) => target.style.height = `${val}px`
+            },
+            {
+                label: 'Border Radius',
+                type: 'range',
+                property: 'borderRadius',
+                min: 0, max: 64, value: 24, unit: 'px', // Default 1.5rem ~ 24px
+                onChange: (val, target) => target.style.borderRadius = `${val}px`
+            },
+            {
+                label: 'Padding',
+                type: 'range',
+                property: 'padding',
+                min: 0, max: 64, value: 24, unit: 'px', // Default 1.5rem ~ 24px
+                onChange: (val, target) => target.style.padding = `${val}px`
+            },
+            {
+                label: 'Font Size',
+                type: 'range',
+                property: 'fontSize',
+                min: 10, max: 32, value: 16, unit: 'px',
+                onChange: (val, target) => target.style.fontSize = `${val}px`
+            },
+            {
+                label: 'Background Color',
+                type: 'select',
+                property: 'backgroundColor',
+                options: ['Default', 'var(--black-3)', 'var(--black-1)', 'var(--white-1)', 'var(--white-2)', 'var(--blue-1)', 'var(--orange-1)'],
+                onChange: (val, target) => target.style.background = val === 'Default' ? '' : val
+            },
+            {
+                label: 'Text/Icon Color',
+                type: 'select',
+                property: 'color',
+                options: ['Default', 'var(--white-1)', 'var(--white-2)', 'var(--black-3)', 'var(--black-1)', 'var(--gray-1)', 'var(--blue-3)', 'var(--orange-2)'],
+                onChange: (val, target) => target.style.color = val === 'Default' ? '' : val
+            },
+            {
+                label: 'Font Family',
+                type: 'select',
+                property: 'fontFamily',
+                options: ['System Default', 'Arial, sans-serif', '"Courier New", monospace', 'Georgia, serif', '"Times New Roman", Times, serif'],
+                onChange: (val, target) => target.style.fontFamily = val === 'System Default' ? '' : val
+            },
+            {
+                label: 'Display',
+                type: 'select',
+                property: 'display',
+                options: ['flex', 'block', 'grid', 'inline-block'],
+                onChange: (val, target) => target.style.display = val
+            },
+            {
+                label: 'Transform',
+                type: 'text',
+                property: 'transform',
+                placeholder: 'e.g., scale(0.9) rotate(5deg)',
+                onChange: (val, target) => target.style.transform = val
+            },
+            {
+                label: 'Transition',
+                type: 'text',
+                property: 'transition',
+                placeholder: 'e.g., all 0.3s ease',
+                onChange: (val, target) => target.style.transition = val
+            }
+        ];
+
+        componentWrappers.forEach((wrapper) => {
+            // Instantiate the agnostic config panel manager
+            new ConfigPanelManager({
+                target: wrapper,
+                schema: labControlSchema
+            });
+
+            // Listen to the dispatched CustomEvents to handle UI state explicitly in the consuming file
+            wrapper.addEventListener('config-open', () => {
+                const grid = wrapper.closest('.components-grid');
+                wrapper.classList.add('is-configuring');
+                if (grid) grid.classList.add('has-active-config');
+            });
+
+            wrapper.addEventListener('config-close', () => {
+                const grid = wrapper.closest('.components-grid');
+                wrapper.classList.remove('is-configuring');
+                // Check if any other popovers are still open (unlikely due to popover auto behavior, but safe)
+                if (grid && !document.querySelector('.is-configuring')) {
+                    grid.classList.remove('has-active-config');
+                }
+            });
+        });
 
     </script>
 </body>

--- a/scripts/utils/ConfigPanelManager.js
+++ b/scripts/utils/ConfigPanelManager.js
@@ -1,0 +1,132 @@
+export class ConfigPanelManager {
+    constructor(options) {
+        this.target = options.target;
+        this.schema = options.schema || [];
+        this.id = `config-popover-${Math.random().toString(36).substr(2, 9)}`;
+        this._init();
+    }
+
+    _init() {
+        // Create the Config Button
+        this.configBtn = document.createElement('button');
+        this.configBtn.className = 'config-btn';
+        this.configBtn.setAttribute('popovertarget', this.id);
+        this.configBtn.setAttribute('title', 'Configure Component');
+        this.configBtn.innerHTML = `
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+                <path d="M240-400q-33 0-56.5-23.5T160-480q0-33 23.5-56.5T240-560q33 0 56.5 23.5T320-480q0 33-23.5 56.5T240-400Zm240 0q-33 0-56.5-23.5T400-480q0-33 23.5-56.5T480-560q33 0 56.5 23.5T560-480q0 33-23.5 56.5T480-400Zm240 0q-33 0-56.5-23.5T640-480q0-33 23.5-56.5T720-560q33 0 56.5 23.5T800-480q0 33-23.5 56.5T720-400Z"/>
+            </svg>
+        `;
+
+        // Append the button to the target element (or optionally another anchor)
+        // Assuming the target is position: relative to anchor the button correctly
+        this.target.appendChild(this.configBtn);
+
+        // Create the Popover
+        this.popover = document.createElement('div');
+        this.popover.id = this.id;
+        this.popover.className = 'config-popover';
+        this.popover.setAttribute('popover', 'auto');
+
+        const header = document.createElement('div');
+        header.className = 'config-popover-header';
+        header.innerHTML = `
+            <h4>Configuration</h4>
+            <button class="config-popover-close" popovertarget="${this.id}" popovertargetaction="hide">
+                <svg xmlns="http://www.w3.org/2000/svg" height="20px" viewBox="0 -960 960 960" width="20px" fill="currentColor">
+                    <path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/>
+                </svg>
+            </button>
+        `;
+        this.popover.appendChild(header);
+
+        // Build controls based on schema
+        this.schema.forEach(ctrl => {
+            const group = document.createElement('div');
+            group.className = 'config-control-group';
+
+            const label = document.createElement('label');
+            label.textContent = ctrl.label;
+
+            const valueDisplay = document.createElement('span');
+            valueDisplay.className = 'config-control-value';
+
+            // Helper to update the display
+            const updateDisplay = (val) => {
+                if (ctrl.type === 'range') {
+                    valueDisplay.textContent = `${val}${ctrl.unit || ''}`;
+                } else if (ctrl.type === 'select' || ctrl.type === 'text') {
+                    valueDisplay.textContent = val || 'Default';
+                }
+            };
+
+            let input;
+            if (ctrl.type === 'select') {
+                input = document.createElement('select');
+                ctrl.options.forEach(opt => {
+                    const option = document.createElement('option');
+                    option.value = opt;
+                    option.textContent = opt;
+                    const currentVal = this.target.style[ctrl.property];
+                    if (currentVal === opt || (opt === 'Default' && !currentVal) || (opt === 'flex' && !currentVal && ctrl.property === 'display')) {
+                        option.selected = true;
+                    }
+                    input.appendChild(option);
+                });
+
+                updateDisplay(input.value);
+                input.addEventListener('change', (e) => {
+                    ctrl.onChange(e.target.value, this.target);
+                    updateDisplay(e.target.value);
+                });
+            } else if (ctrl.type === 'text') {
+                input = document.createElement('input');
+                input.type = 'text';
+                input.placeholder = ctrl.placeholder || '';
+                input.value = this.target.style[ctrl.property] || '';
+
+                updateDisplay(input.value);
+                input.addEventListener('input', (e) => {
+                    ctrl.onChange(e.target.value, this.target);
+                    updateDisplay(e.target.value);
+                });
+            } else {
+                input = document.createElement('input');
+                input.type = ctrl.type;
+                if (ctrl.type === 'range') {
+                    if(ctrl.min !== undefined) input.min = ctrl.min;
+                    if(ctrl.max !== undefined) input.max = ctrl.max;
+                }
+
+                // Determine initial value safely
+                let initialValue = ctrl.value;
+                if(typeof initialValue === 'function') {
+                    initialValue = initialValue(this.target);
+                }
+                input.value = initialValue !== undefined ? initialValue : '';
+
+                updateDisplay(input.value);
+                input.addEventListener('input', (e) => {
+                    ctrl.onChange(e.target.value, this.target);
+                    updateDisplay(e.target.value);
+                });
+            }
+
+            group.appendChild(label);
+            group.appendChild(input);
+            group.appendChild(valueDisplay);
+            this.popover.appendChild(group);
+        });
+
+        // Add Event Listeners for State Management
+        this.popover.addEventListener('toggle', (e) => {
+            if (e.newState === 'open') {
+                this.target.dispatchEvent(new CustomEvent('config-open', { bubbles: true }));
+            } else {
+                this.target.dispatchEvent(new CustomEvent('config-close', { bubbles: true }));
+            }
+        });
+
+        document.body.appendChild(this.popover);
+    }
+}

--- a/tests-e2e/components-config.spec.js
+++ b/tests-e2e/components-config.spec.js
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Component Configuration Panel', () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the components lab page
+    await page.goto('/lab/components.html');
+  });
+
+  test('should open the configuration popover when clicking the config button', async ({ page }) => {
+    const configBtn = page.locator('.config-btn').first();
+    const popover = page.locator('.config-popover').first();
+
+    await expect(popover).toBeHidden();
+
+    // Popover click sometimes needs dispatchEvent in webkit/chromium headless mode
+    await configBtn.dispatchEvent('click');
+
+    await expect(popover).toBeVisible();
+
+    // Check if header exists
+    await expect(popover.locator('h4')).toHaveText('Configuration');
+  });
+
+  test('should update component styles when modifying a control', async ({ page }) => {
+    const wrapper = page.locator('.component-wrapper').first();
+    const configBtn = wrapper.locator('.config-btn');
+    const popover = page.locator('.config-popover').first();
+
+    await configBtn.dispatchEvent('click');
+
+    // Ensure popover is visible before interacting
+    await expect(popover).toBeVisible();
+
+    // Find the 'Inline Size' range input
+    const widthInput = popover.locator('.config-control-group').filter({ hasText: 'Inline Size' }).locator('input[type="range"]');
+
+    // Set a new width value
+    await widthInput.fill('400');
+    // Dispatch input event to trigger the JS logic
+    await widthInput.dispatchEvent('input');
+
+    // Verify the inline style was updated
+    await expect(wrapper).toHaveCSS('width', '400px');
+
+    // Verify the value display column was updated
+    const valueDisplay = popover.locator('.config-control-group').filter({ hasText: 'Inline Size' }).locator('.config-control-value');
+    await expect(valueDisplay).toHaveText('400px');
+  });
+
+  test('should apply active focus and background blur states when opened', async ({ page }) => {
+    const wrapper = page.locator('.component-wrapper').first();
+    const configBtn = wrapper.locator('.config-btn');
+    const grid = page.locator('.components-grid');
+
+    // Initially neither should have the active classes
+    await expect(wrapper).not.toHaveClass(/is-configuring/);
+    await expect(grid).not.toHaveClass(/has-active-config/);
+
+    // Open the popover
+    await configBtn.dispatchEvent('click');
+    await expect(page.locator('.config-popover').first()).toBeVisible();
+
+    // Verify the classes were applied
+    await expect(wrapper).toHaveClass(/is-configuring/);
+    await expect(grid).toHaveClass(/has-active-config/);
+
+    // Verify the blur effect is applied to OTHER wrappers
+    const secondWrapper = page.locator('.component-wrapper').nth(1);
+    await expect(secondWrapper).toHaveCSS('opacity', '0.4');
+    await expect(secondWrapper).toHaveCSS('filter', 'blur(4px)');
+
+    // Verify the outline is applied to the ACTIVE wrapper
+    await expect(wrapper).toHaveCSS('outline-style', 'solid');
+    await expect(wrapper).toHaveCSS('outline-width', '2px');
+    await expect(wrapper).toHaveCSS('outline-color', /oklch\(0\.73296 0\.158839 37\.5332\)|rgb\(244, 155, 62\)/); // --orange-3 fallback value usually computed
+
+    // Close the popover
+    const closeBtn = page.locator('.config-popover').first().locator('.config-popover-close');
+    await closeBtn.dispatchEvent('click');
+
+    // Verify the classes were removed
+    await expect(wrapper).not.toHaveClass(/is-configuring/);
+    await expect(grid).not.toHaveClass(/has-active-config/);
+  });
+});


### PR DESCRIPTION
Relocates the `ConfigPanelManager` class into the `scripts/utils` directory to promote better organization. Since the class was refactored to be completely framework and element agnostic, placing it in the general utilities folder makes it explicitly clear that it can be imported and utilized anywhere in the project, not just within the lab environment.

---
*PR created automatically by Jules for task [7252107462614902505](https://jules.google.com/task/7252107462614902505) started by @rmjames*