### PR TITLE
style: remove .reset-btn from styles/lab-shared.css

### DIFF
--- a/styles/lab-shared.css
+++ b/styles/lab-shared.css
@@ -72,40 +72,4 @@ html.from-lab .back-link {
 html.in-iframe .back-link {
     display: none !important;
 }
-
-.reset-btn {
-    position: fixed;
-    inset-block-end: max(1.25rem, 4cqi);
-    inset-inline-end: max(1.25rem, 4cqi);
-    background: transparent;
-    color: currentColor;
-    border: none;
-    cursor: pointer;
-    padding: .5rem;
-    display: grid;
-    place-items: center;
-    border-radius: 50%;
-    opacity: .5;
-    transition: opacity .2s, transform .2s;
-    z-index: 100;
-    min-inline-size: 2.75rem;
-    min-block-size: 2.75rem;
-
-    svg {
-        inline-size: 1.5rem;
-        block-size: 1.5rem;
-        display: block;
-    }
-
-    &:hover {
-        opacity: 1;
-        transform: scale(1.1);
-    }
-
-    &:focus-visible {
-        opacity: 1;
-        outline: 2px solid currentColor;
-        outline-offset: 2px;
-    }
-}
 /*# sourceMappingURL=lab-shared.css.map */


### PR DESCRIPTION
Removes the `.reset-btn` selector and its styles from `styles/lab-shared.css` as requested.

---
*PR created automatically by Jules for task [4468096008668979751](https://jules.google.com/task/4468096008668979751) started by @rmjames*